### PR TITLE
Avoid KeyError exception on tags dictionary

### DIFF
--- a/chart.py
+++ b/chart.py
@@ -70,8 +70,13 @@ def create_chart(overall_result,tag_results =''):
         tag_list.append(key)
 
     for tags in tag_list:
-        passed_values.append(tag_results[tags]['pass'])
-        failed_values.append(tag_results[tags]['fail'])
+        if 'pass' in tag_results[tags] and 'fail' in tag_results[tags]:
+            passed_values.append(tag_results[tags]['pass'])
+            failed_values.append(tag_results[tags]['fail'])
+        else:
+            passed_values.append(0)
+            failed_values.append(0)
+            print('tag "{0}" has no associated results'.format(tags))
 
     trace1 = go.Bar(
         x=tag_list,


### PR DESCRIPTION
Hi, 
I don't know exactly why but some tags in my report as no pass/fail so there is an exception.

    Traceback (most recent call last):
      File "robo_graph.py", line 70, in <module>
        robo_graph_generator()
      File "robo_graph.py", line 61, in robo_graph_generator
        html_data = create_chart(overall_result,tag_results)
      File "c:\Users\CYRIL_~1\AppData\Local\Temp\RoboReport\chart.py", line 73, in create_chart
        passed_values.append(tag_results[tags]['pass'])
    KeyError: 'pass'
    exit status 1

I just add a control and a message in the console.
